### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotSatisfyPredicateRecursively.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotSatisfyPredicateRecursively.java
@@ -30,7 +30,7 @@ public class ShouldNotSatisfyPredicateRecursively extends BasicErrorMessageFacto
     List<String> fieldsDescription = failedFields.stream().map(FieldLocation::getPathToUseInErrorReport).collect(toList());
     StringBuilder builder = new StringBuilder(NEW_LINE);
     builder.append("The following fields did not satisfy the predicate:").append(NEW_LINE);
-    builder.append(INDENT + fieldsDescription.toString() + NEW_LINE);
+    builder.append(INDENT + fieldsDescription + NEW_LINE);
     builder.append("The recursive assertion was performed with this configuration:").append(NEW_LINE);
     builder.append(recursiveAssertionConfiguration);
     return new ShouldNotSatisfyPredicateRecursively(builder.toString());

--- a/assertj-core/src/main/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy.java
@@ -168,7 +168,7 @@ public class ComparatorBasedComparisonStrategy extends AbstractComparisonStrateg
 
   @Override
   public String asText() {
-    return "when comparing values using " + toString();
+    return "when comparing values using " + ;
   }
 
   @Override


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:-1069463600 -->
<!-- fingerprint:-2022663181 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (2)
